### PR TITLE
入力レイヤ・出力レイヤを選択するuiを追加

### DIFF
--- a/dem_to_csmap.py
+++ b/dem_to_csmap.py
@@ -35,3 +35,5 @@ class DemToCsMap(QDialog):
             chunk_size=256,
             params=params,
         )
+
+        self.close()

--- a/dem_to_csmap.ui
+++ b/dem_to_csmap.ui
@@ -27,7 +27,7 @@
    <item>
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>出力レイヤ</string>
+      <string>出力フォルダ</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->
- UI画面で入力レイヤ（現状はtifのみ）と出力先を指定できるようにしました。
- 出力されたCS立体図は選択したフォルダに"csmap.tif"という名前で保存されます。
- QGISでの動作を確認済みです。

- ...

### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->

Not required / 不要


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - CSMap処理用のユーザーインターフェースを改良し、ファイル選択フィルタ、ストレージモード、入力/出力パスの処理を追加しました。

- **スタイル**
  - ダイアログインターフェースのレイアウトとウィジェットを調整し、ボタンのテキストを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->