### PR TITLE
処理終了後にcsmap.tifをレイヤに追加

### DIFF
--- a/dem_to_csmap.py
+++ b/dem_to_csmap.py
@@ -30,15 +30,16 @@ class DemToCsMap(QDialog):
         # 入力・出力をUIで操作
         input_path = self.ui.mQgsFileWidget.filePath()
         output_dir = self.ui.mQgsFileWidget_.filePath()
+        output_path = os.path.join(output_dir, 'csmap.tif')
 
         process.process(
             input_path,
-            output_path=output_dir + '/csmap.tif',
+            output_path,
             chunk_size=256,
             params=params,
         )
 
         # csmap.tifをQGISに読み込む
-        iface.addRasterLayer(os.path.join(output_dir, 'csmap.tif'), 'csmap')
+        iface.addRasterLayer(output_path)
 
         self.close()

--- a/dem_to_csmap.ui
+++ b/dem_to_csmap.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>357</width>
+    <width>524</width>
     <height>168</height>
    </rect>
   </property>
@@ -37,16 +37,16 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="pushButton_run">
+      <widget class="QPushButton" name="pushButton_cancel">
        <property name="text">
-        <string>Run</string>
+        <string>Cancel</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pushButton_cancel">
+      <widget class="QPushButton" name="pushButton_run">
        <property name="text">
-        <string>Cancel</string>
+        <string>Run</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #11 

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->
- 処理実行後，"出力先フォルダ"に保存された"csmap.tif"がレイヤに追加されるようにした。
...

### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->
- Slackで共有した.tifを入力レイヤとしてプラグインを実行してください。
- 現状，”出力フォルダ”では出力したいフォルダを選択して終了です。
- 出力されるCS立体図はcsmap.tifとして出力されます。
- CS立体図がレイヤに追加されてプラグインが自動で終了したら成功です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - QGISに処理されたラスターレイヤーを追加する機能を追加しました。

- **ユーザーインターフェースの改善**
  - ファイル選択フィルタ、ストレージモード、入出力パスの調整。
  - ダイアログインターフェースのレイアウトとウィジェットを変更し、新しいウィジェットを追加しました。

- **バグ修正**
  - `output_dir`と`output_path`の割り当てを更新。
  - `process.process`呼び出しの`chunk_size`パラメータを256に更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->