### PR TITLE
feature:出力先で名前をつけて保存

### DIFF
--- a/dem_to_csmap.py
+++ b/dem_to_csmap.py
@@ -1,6 +1,7 @@
 import os
 
 from PyQt5.QtWidgets import QDialog
+from qgis.gui import QgsFileWidget
 from qgis.PyQt import uic
 from qgis.utils import iface
 
@@ -16,11 +17,17 @@ class DemToCsMap(QDialog):
 
         # ウィンドウタイトル
         self.setWindowTitle("CSMap Plugin")
-        # QGISでサポートされているラスタデータのみ選択可能
-        self.ui.mQgsFileWidget.setFilter('*.tif;;*.tiff;;*.dt0;;*.dt1;;*.dt2;;*.dem;;*.asc;;*.adf;;*.hgt;;*.bil;;*.nc;;*.img;;*.flt;;*.bt;;*.xyz;;*.grd;;*.ter')
-        # 出力先をフォルダに指定
-        self.ui.mQgsFileWidget_.setStorageMode(1)
 
+        # QGISでサポートされているラスタデータのみ選択可能
+        self.ui.mQgsFileWidget.setFilter(
+            "*.tif;;*.tiff;;*.dt0;;*.dt1;;*.dt2;;*.dem;;*.asc;;*.adf;;*.hgt;;*.bil;;*.nc;;*.img;;*.flt;;*.bt;;*.xyz;;*.grd;;*.ter"
+        )
+
+        # 出力データの設定
+        self.ui.mQgsFileWidget_output.setFilter("*.tif")
+        self.ui.mQgsFileWidget_output.setStorageMode(QgsFileWidget.StorageMode.SaveFile)
+
+        # ボタンのクリックイベント
         self.ui.pushButton_run.clicked.connect(self.convert_dem_to_csmap)
         self.ui.pushButton_cancel.clicked.connect(self.close)
 
@@ -29,8 +36,7 @@ class DemToCsMap(QDialog):
 
         # 入力・出力をUIで操作
         input_path = self.ui.mQgsFileWidget.filePath()
-        output_dir = self.ui.mQgsFileWidget_.filePath()
-        output_path = os.path.join(output_dir, 'csmap.tif')
+        output_path = self.ui.mQgsFileWidget_output.filePath()
 
         process.process(
             input_path,
@@ -39,7 +45,7 @@ class DemToCsMap(QDialog):
             params=params,
         )
 
-        # csmap.tifをQGISに読み込む
-        iface.addRasterLayer(output_path)
+        # 出力結果をQGISに追加
+        iface.addRasterLayer(output_path, os.path.basename(output_path))
 
         self.close()

--- a/dem_to_csmap.ui
+++ b/dem_to_csmap.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>524</width>
+    <width>389</width>
     <height>168</height>
    </rect>
   </property>
@@ -27,12 +27,12 @@
    <item>
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>出力フォルダ</string>
+      <string>出力レイヤ</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QgsFileWidget" name="mQgsFileWidget_"/>
+    <widget class="QgsFileWidget" name="mQgsFileWidget_output"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
<!-- Close or Related Issues -->

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->
-これまでは出力先フォルダを指定するだけだったが，出力したい場所で名前をつけて保存し，その結果がレイヤに追加されるようにした。
 ...

### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->
- QGISでプラグインを実行してください。
- "出力レイヤ"で保存先を指定して，名前をつけて保存できるか確認してください。
- 保存した名前.tifがレイヤに追加されたら成功です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 入力および出力データのファイルフィルタを追加しました。
  - 出力パスの処理を改善しました。
  - 変換とキャンセル操作のボタンクリックイベントの処理を調整しました。

- **スタイル**
  - QLabelウィジェットのテキストを「出力フォルダ」から「出力レイヤ」に変更しました。
  - QgsFileWidgetの名前を「mQgsFileWidget_」から「mQgsFileWidget_output」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->